### PR TITLE
Adjust versioning scripts to fail if the csproj file cannot be modified

### DIFF
--- a/src/Results.Immutable.Extensions.FluentAssertions/package.json
+++ b/src/Results.Immutable.Extensions.FluentAssertions/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "results-immutable-extensions-fluent-assertions",
+  "name": "Results.Immutable.Extensions.FluentAssertions",
   "private": true,
   "version": "0.1.0-alpha.4",
   "scripts": {
-    "version": "node ../../scripts/version.mjs; git add Results.Immutable.Extensions.FluentAssertions.csproj"
+    "version": "node ../../scripts/version.mjs && git add Results.Immutable.Extensions.FluentAssertions.csproj"
   }
 }

--- a/src/Results.Immutable/package.json
+++ b/src/Results.Immutable/package.json
@@ -4,6 +4,6 @@
   "version": "0.1.0-alpha.4",
   "packageManager": "yarn@3.5.0",
   "scripts": {
-    "version": "node ../../scripts/version.mjs; git add Results.Immutable.csproj"
+    "version": "node ../../scripts/version.mjs && git add Results.Immutable.csproj"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,6 +911,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"Results.Immutable.Extensions.FluentAssertions@workspace:src/Results.Immutable.Extensions.FluentAssertions":
+  version: 0.0.0-use.local
+  resolution: "Results.Immutable.Extensions.FluentAssertions@workspace:src/Results.Immutable.Extensions.FluentAssertions"
+  languageName: unknown
+  linkType: soft
+
 "Results.Immutable@workspace:src/Results.Immutable":
   version: 0.0.0-use.local
   resolution: "Results.Immutable@workspace:src/Results.Immutable"
@@ -5000,12 +5006,6 @@ __metadata:
   checksum: f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
   languageName: node
   linkType: hard
-
-"results-immutable-extensions-fluent-assertions@workspace:src/Results.Immutable.Extensions.FluentAssertions":
-  version: 0.0.0-use.local
-  resolution: "results-immutable-extensions-fluent-assertions@workspace:src/Results.Immutable.Extensions.FluentAssertions"
-  languageName: unknown
-  linkType: soft
 
 "results-immutable-workspaces@workspace:.":
   version: 0.0.0-use.local


### PR DESCRIPTION
- Adjusted versioning scripts so that the operation fails if the csproj cannot be edited.
- Renamed package to match the csproj filename.