### PR TITLE
Async to sync projections

### DIFF
--- a/src/Results.Immutable.Extensions.FluentAssertions/package.json
+++ b/src/Results.Immutable.Extensions.FluentAssertions/package.json
@@ -6,6 +6,6 @@
     "version": "node ../../scripts/version.mjs && git add Results.Immutable.Extensions.FluentAssertions.csproj"
   },
   "devDependencies": {
-    "Results.Immutable": "^0.1.0-alpha.5"
+    "Results.Immutable": "0.1.0-alpha.5"
   }
 }

--- a/src/Results.Immutable.Tests/ExtensionsTests/AsyncProjectionsTests.cs
+++ b/src/Results.Immutable.Tests/ExtensionsTests/AsyncProjectionsTests.cs
@@ -16,7 +16,9 @@ public sealed class AsyncProjectionsTests
         .Should()
         .BeEquivalentTo(Result.Ok());
 
-    [Fact(DisplayName = "Projecting a failed result should return a new, equivalent result without ")]
+    [Fact(
+        DisplayName =
+            "Projecting a failed result should return a new, equivalent result without calling the projecting delegate")]
     public async Task ProjectionOnAFailedResultShouldReturnANewEquivalentFailedResult()
     {
         const string errorMessage = "An error";
@@ -36,14 +38,29 @@ public sealed class AsyncProjectionsTests
             throw new InvalidOperationException("Projection on a failed result was executed!");
     }
 
+    [Fact(DisplayName = "Projecting a successful async result should return a new result with matching value")]
+    public async Task ProjectionOfASuccessfulResultShouldReturnAResultWithMatchingValue()
+    {
+        const int newValue = 2137;
+        var result = await SuccessfulAsyncResult.SelectAsync(static _ => new ValueTask<int>(newValue));
+
+        result.Should()
+            .Match<Result<int>>(static r => r.Some!.Value.Value == newValue);
+    }
+
+    [Fact(DisplayName = "Asynchronous no-op projection of a successful result of unit should return a result of unit")]
+    public async Task AsynchronousNoOpProjectionOfASuccessfulResultShouldReturnAResultOfUnit() =>
+        (await SuccessfulAsyncResult.SelectAsync(_ => new ValueTask<Unit>(Unit.Value)))
+        .Should()
+        .BeEquivalentTo(Result.Ok());
+
     [Fact(DisplayName = "No-op asynchronous projection of multiple async results should return a result of unit")]
     public async Task NoOpProjectionOfMultipleResultsShouldReturnResultOfUnit() =>
-        (await SuccessfulAsyncResult.SelectMany(static _ => new ValueTask<Result<Unit>>(Result.Ok())))
+        (await SuccessfulAsyncResult.SelectManyAsync(static _ => new ValueTask<Result<Unit>>(Result.Ok())))
         .Should()
         .Be(Result.Ok());
 
-    [Property(
-        DisplayName = "Projecting two asynchronous results should return a matching result based on the second result")]
+    [Property(DisplayName = "Projecting two asynchronous results should return a matching result")]
     public Property ProjectingTwoAsyncResultsShouldReturnAMatchingResultBasedOnTheSecondResult() =>
         Prop.ForAll(
             SelectMany.Generator()
@@ -51,22 +68,23 @@ public sealed class AsyncProjectionsTests
             static async tuple =>
             {
                 var (first, second, _, _) = tuple;
+                var combination = await CombineAsync(first, second);
 
                 return (first, second) switch
                 {
                     ({ IsOk: true, }, { Some.Value: var finalValue, }) =>
-                        await Combine(first, second) is { Some.Value: var value, } &&
+                        combination is { Some.Value: var value, } &&
                         value?.Equals(finalValue) is true or null,
-                    ({ HasFailed: true, }, _) => await Combine(first, second) is var failedResult &&
+                    ({ HasFailed: true, }, _) => combination is var failedResult &&
                         failedResult.HasError(static (Error e) => e.Message == "First errored out"),
-                    _ => await Combine(first, second) is var failedResult &&
+                    _ => combination is var failedResult &&
                         failedResult.HasError(static (Error e) => e.Message == "Second errored out"),
                 };
             });
 
     [Property(
         DisplayName =
-            "Projecting two asynchronous results should return a matching result based on final selector")]
+            "Projecting asynchronous and synchronous results should return a matching result based on final selector")]
     public Property ProjectingTwoAsyncResultsShouldReturnAMatchingResultBasedOnFinalSelector() =>
         Prop.ForAll(
             SelectMany.Generator()
@@ -97,7 +115,7 @@ public sealed class AsyncProjectionsTests
 
     [Property(
         DisplayName =
-            "Projecting two asynchronous results should return a matching result based on final selector (query syntax)")]
+            "Projecting asynchronous and synchronous results should return a matching result based on final selector (query syntax)")]
     public Property ProjectingTwoAsyncResultsWithQuerySyntaxShouldReturnAMatchingResultBasedOnFinalSelector() =>
         Prop.ForAll(
             SelectMany.Generator()
@@ -118,8 +136,37 @@ public sealed class AsyncProjectionsTests
 
                 ValueTask<Result<object?>> CombineWithQuery() =>
                     from initialValue in ToValueTask(first)
-                    from intermediateValue in ToValueTask(second)
+                    from intermediateValue in second
                     select selector(initialValue, intermediateValue);
+            });
+
+    [Property(DisplayName = "Projecting two asynchronous results should return a value based on the final selector")]
+    public Property ProjectingTwoAsyncResultsShouldReturnAMatchingResultWithValueBasedOnTheFinalSelector() =>
+        Prop.ForAll(
+            SelectMany.Generator()
+                .ToArbitrary(),
+            static async tuple =>
+            {
+                var (first, second, selector, finalValue) = tuple;
+
+                return (first, second) switch
+                {
+                    ({ IsOk: true, }, { IsOk: true, }) => await CombineAsync(
+                            first,
+                            second,
+                            selector) is { Some.Value: var value, } &&
+                        value?.Equals(finalValue) is null or true,
+                    ({ HasFailed: true, }, _) => await CombineAsync(
+                            first,
+                            second,
+                            selector) is var failedResult &&
+                        failedResult.HasError(static (Error e) => e.Message == "First errored out"),
+                    _ => await CombineAsync(
+                            first,
+                            second,
+                            selector) is var failure &&
+                        failure.HasError<Error>(static e => e.Message == "Second errored out"),
+                };
             });
 
     private static async ValueTask<Result<object?>> Combine(
@@ -128,11 +175,21 @@ public sealed class AsyncProjectionsTests
         Func<object?, object?, object?>? selector = null) =>
         selector is null
             ? await ToValueTask(first)
-                .SelectMany(_ => ToValueTask(second))
+                .SelectMany(_ => second)
             : await ToValueTask(first)
                 .SelectMany(
-                    _ => ToValueTask(second),
+                    _ => second,
                     selector);
+
+    private static async ValueTask<Result<object?>> CombineAsync(
+        Result<object?> first,
+        Result<object?> second,
+        Func<object?, object?, object?>? selector = null) =>
+        selector is null
+            ? await ToValueTask(first)
+                .SelectManyAsync(_ => ToValueTask(second))
+            : await ToValueTask(first)
+                .SelectManyAsync(_ => ToValueTask(second), selector);
 
     private static ValueTask<Result<object?>> ToValueTask(Result<object?> result) => new(result);
 }

--- a/src/Results.Immutable/Extensions/TaskOfResultExtensions.cs
+++ b/src/Results.Immutable/Extensions/TaskOfResultExtensions.cs
@@ -15,14 +15,14 @@ public static class TaskOfResultExtensions
     /// <typeparam name="T">Generic type of the <see cref="Result{T}" />.</typeparam>
     /// <typeparam name="TNew">Generic type of the new <see cref="Result{T}" />.</typeparam>
     /// <param name="task">
-    ///     A <see cref="Task{T}" /> of <see cref="Result{T}" />,
+    ///     A <see cref="ValueTask{T}" /> of <see cref="Result{T}" />,
     ///     representing the result of an asynchronous operation.
     /// </param>
     /// <param name="selector">
     ///     Delegate to execute.
     /// </param>
     /// <returns>
-    ///     A <see cref="Task{T}" />, representing the result of an asynchronous operation,
+    ///     A <see cref="ValueTask{T}" />, representing the result of an asynchronous operation,
     ///     wrapping the <see cref="Result{T}" /> of <typeparamref name="TNew" />.
     /// </returns>
     public static async ValueTask<Result<TNew>> Select<T, TNew>(
@@ -33,30 +33,71 @@ public static class TaskOfResultExtensions
             : Result.Fail<TNew>(result.Errors);
 
     /// <summary>
-    ///     Projects the <see cref="Result{T}" />
-    ///     of this <paramref name="task" />
-    ///     using a provided <paramref name="asyncResultSelector" />,
-    ///     flattening the structure.
+    ///     Projects the result of this <paramref name="task" />
+    ///     into a <see cref="Result{T} " /> of <typeparamref name="TNew" />
+    ///     asynchronously by applying provided
+    ///     <paramref name="asyncSelector" />.
     /// </summary>
-    /// <typeparam name="T">Generic type of the <see cref="Result{T}" />.</typeparam>
-    /// <typeparam name="TNew">Generic type of the new <see cref="Result{T}" />.</typeparam>
+    /// <typeparam name="T">
+    ///     Generic type of the initial result.
+    /// </typeparam>
+    /// <typeparam name="TNew">
+    ///     Generic type of the returned result.
+    /// </typeparam>
     /// <param name="task">
-    ///     A <see cref="Task{T}" /> of <see cref="Result{T}" />,
-    ///     representing the result of an asynchronous operation.
+    ///     A <see cref="ValueTask{T}" /> of <see cref="Result{T}" />
+    ///     to project.
     /// </param>
-    /// <param name="asyncResultSelector">
-    ///     Delegate to execute.
+    /// <param name="asyncSelector">
+    ///     Asynchronous projecting function.
     /// </param>
     /// <returns>
-    ///     A <see cref="Task{T}" />, representing the result of an asynchronous operation,
-    ///     wrapping the <see cref="Result{T}" /> of <typeparamref name="TNew" />.
+    ///     A <see cref="ValueTask{T}" />, representing the result
+    ///     of an asynchronous projection of the underlying
+    ///     <see cref="Result{T}" />.
+    /// </returns>
+    public static async ValueTask<Result<TNew>> SelectAsync<T, TNew>(
+        this ValueTask<Result<T>> task,
+        Func<T, ValueTask<TNew>> asyncSelector)
+    {
+        var result = await task;
+        return result is { Some.Value: var value, }
+            ? Result.Ok(await asyncSelector(value))
+            : Result.Fail<TNew>(result.Errors);
+    }
+
+    /// <summary>
+    ///     Projects the <paramref name="task" /> and flattens
+    ///     the <see cref="Result{T}" /> obtained from executing
+    ///     the <paramref name="selector" />.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     Generic type of the initial result.
+    /// </typeparam>
+    /// <typeparam name="TNew">
+    ///     Generic type of the final result.
+    /// </typeparam>
+    /// <param name="task">
+    ///     A <see cref="ValueTask{T}" /> of <see cref="Result{T}" />
+    ///     to project.
+    /// </param>
+    /// <param name="selector">
+    ///     Delgate used to project successful result.
+    /// </param>
+    /// <returns>
+    ///     A <see cref="ValueTask{T}" />,
+    ///     representing the result of an asynchronous operation, which wraps
+    ///     the projected <see cref="Result{T}" /> of
+    ///     <typeparamref name="TNew" />.
     /// </returns>
     public static async ValueTask<Result<TNew>> SelectMany<T, TNew>(
         this ValueTask<Result<T>> task,
-        Func<T, ValueTask<Result<TNew>>> asyncResultSelector) =>
-        await task is var result && result is { Some.Value: var value, }
-            ? await asyncResultSelector(value)
-            : Result.Fail<TNew>(result.Errors);
+        Func<T, Result<TNew>> selector)
+    {
+        var result = await task;
+
+        return result is { Some.Value: var value, } ? selector(value) : Result.Fail<TNew>(result.Errors);
+    }
 
     /// <summary>
     ///     Projects the <see cref="Result{T}" /> into a new <see cref="Result{T}" />
@@ -66,7 +107,7 @@ public static class TaskOfResultExtensions
     /// <typeparam name="TIntermediate">The type of the intermediate value.</typeparam>
     /// <typeparam name="TNew">The type of the final value.</typeparam>
     /// <param name="task">
-    ///     A <see cref="Task{T}" />, representing the result of an asynchronous
+    ///     A <see cref="ValueTask{T}" />, representing the result of an asynchronous
     ///     operation, wrapping the <see cref="Result{T}" />.
     /// </param>
     /// <param name="intermediateSelector">
@@ -76,22 +117,101 @@ public static class TaskOfResultExtensions
     ///     Selector for the final result value.
     /// </param>
     /// <returns>
-    ///     A <see cref="Task{T}" />, representing the result of an asynchronous
+    ///     A <see cref="ValueTask{T}" />, representing the result of an asynchronous
     ///     operation, wrapping the <see cref="Result{T}" /> of <typeparamref name="TNew" />.
     /// </returns>
     public static async ValueTask<Result<TNew>> SelectMany<T, TIntermediate, TNew>(
         this ValueTask<Result<T>> task,
-        Func<T, ValueTask<Result<TIntermediate>>> intermediateSelector,
+        Func<T, Result<TIntermediate>> intermediateSelector,
         Func<T, TIntermediate, TNew> resultSelector)
     {
         if (await task is var result && result is { Some.Value: var value, })
         {
-            return await intermediateSelector(value) is var intermediateResult &&
+            return intermediateSelector(value) is var intermediateResult &&
                 intermediateResult is { Some.Value: var intermediate, }
                     ? Result.Ok(resultSelector(value, intermediate))
                     : Result.Fail<TNew>(intermediateResult.Errors);
         }
 
         return Result.Fail<TNew>(result.Errors);
+    }
+
+    /// <summary>
+    ///     Projects the <see cref="Result{T}" />
+    ///     of this <paramref name="task" /> asynchronously,
+    ///     using a provided <paramref name="asyncResultSelector" />
+    ///     and flattening the structure.
+    /// </summary>
+    /// <typeparam name="T">Generic type of the <see cref="Result{T}" />.</typeparam>
+    /// <typeparam name="TNew">Generic type of the new <see cref="Result{T}" />.</typeparam>
+    /// <param name="task">
+    ///     A <see cref="ValueTask{T}" /> of <see cref="Result{T}" />,
+    ///     representing the result of an asynchronous operation.
+    /// </param>
+    /// <param name="asyncResultSelector">
+    ///     Delegate to execute.
+    /// </param>
+    /// <returns>
+    ///     A <see cref="ValueTask{T}" />, representing the result of an asynchronous operation,
+    ///     wrapping the <see cref="Result{T}" /> of <typeparamref name="TNew" />.
+    /// </returns>
+    public static async ValueTask<Result<TNew>> SelectManyAsync<T, TNew>(
+        this ValueTask<Result<T>> task,
+        Func<T, ValueTask<Result<TNew>>> asyncResultSelector) =>
+        await task is var result && result is { Some.Value: var value, }
+            ? await asyncResultSelector(value)
+            : Result.Fail<TNew>(result.Errors);
+
+    /// <summary>
+    ///     Projects the <see cref="Result{T}" />
+    ///     of this <paramref name="task" /> asynchronously,
+    ///     using the provided <paramref name="intermediateSelector" />
+    ///     to obtain intermediate <see cref="Result{T}" /> of
+    ///     <typeparamref name="TIntermediate" /> and
+    ///     <paramref name="resultSelector" /> to project resulting
+    ///     values into <typeparamref name="TNew" />.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     Generic type of the initial <see cref="Result{T}" />.
+    /// </typeparam>
+    /// <typeparam name="TIntermediate">
+    ///     Generic type of the intermediate <see cref="Result{T}" />.
+    /// </typeparam>
+    /// <typeparam name="TNew">
+    ///     Generic type of the final <see cref="Result{T}" />.
+    /// </typeparam>
+    /// <param name="task">
+    ///     A <see cref="ValueTask{T}" /> of <see cref="Result{T}" />,
+    ///     representing the result of an asynchronous operation.
+    /// </param>
+    /// <param name="intermediateSelector">
+    ///     Asynchronous delegate used to obtain the intermediate value.
+    /// </param>
+    /// <param name="resultSelector">
+    ///     Delegate used to project both
+    ///     <typeparamref name="T" /> and <typeparamref name="TIntermediate" />
+    ///     values into <typeparamref name="TNew" />.
+    /// </param>
+    /// <returns>
+    ///     A <see cref="ValueTask{T}" />, representing the result of
+    ///     an asynchronous operation, wrapping the <see cref="Result{T}" />
+    ///     of <typeparamref name="TNew" />.
+    /// </returns>
+    public static async ValueTask<Result<TNew>> SelectManyAsync<T, TIntermediate, TNew>(
+        this ValueTask<Result<T>> task,
+        Func<T, ValueTask<Result<TIntermediate>>> intermediateSelector,
+        Func<T, TIntermediate, TNew> resultSelector)
+    {
+        var initialResult = await task;
+
+        if (initialResult is { Some.Value: var value, })
+        {
+            var intermediateResult = await intermediateSelector(value);
+            return intermediateResult is { Some.Value: var intermediate, }
+                ? Result.Ok(resultSelector(value, intermediate))
+                : Result.Fail<TNew>(intermediateResult.Errors);
+        }
+
+        return Result.Fail<TNew>(initialResult.Errors);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,11 +915,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "Results.Immutable.Extensions.FluentAssertions@workspace:src/Results.Immutable.Extensions.FluentAssertions"
   dependencies:
-    Results.Immutable: 0.1.0-alpha.4
+    Results.Immutable: 0.1.0-alpha.5
   languageName: unknown
   linkType: soft
 
-"Results.Immutable@0.1.0-alpha.4, Results.Immutable@workspace:src/Results.Immutable":
+"Results.Immutable@0.1.0-alpha.5, Results.Immutable@workspace:src/Results.Immutable":
   version: 0.0.0-use.local
   resolution: "Results.Immutable@workspace:src/Results.Immutable"
   languageName: unknown


### PR DESCRIPTION
Renames existing `ValueTask<Result<>>` extensions and adds missing async-to-sync projections, clarifying the intent (`Select/SelectMany` for synchronous-, `SelectAsync/SelectManyAsync` for asynchronous projections).