### PR TITLE
Feat/member-validation

### DIFF
--- a/src/Results.Immutable.Tests/MemberTests/MemberParserTests.cs
+++ b/src/Results.Immutable.Tests/MemberTests/MemberParserTests.cs
@@ -1,0 +1,202 @@
+using System.Linq.Expressions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Results.Immutable.Member;
+using static Results.Immutable.Result;
+
+namespace Results.Immutable.Tests.MemberTests;
+
+public sealed class MemberParserTests
+{
+    public MemberParserTests()
+    {
+        MemberParser.DefaultNamingPolicy = null;
+    }
+
+    [Fact(DisplayName = "Validates values without errors")]
+    public void ValidateAValueWithoutErrors()
+    {
+        var result = new Command("R", 20).ParseMember(
+            c => c.Age,
+            age => OkIf(
+                age > 18,
+                age,
+                new Error("Too young")));
+
+        result.Should()
+            .ContainValue();
+    }
+
+    [Fact(DisplayName = "Validates values that produce errors")]
+    public void ValidateAValueThatProducesErrors()
+    {
+        var command = new Command("R", 13);
+
+        var errorTooYoung = new Error("Too young");
+        var resultAge = command.ParseMember(
+            c => c.Age,
+            age => OkIf(
+                age > 18,
+                age,
+                errorTooYoung),
+            "The user should be an adult");
+
+        Expression<Func<Command, string>> nameSelector = nameSelector = c => c.Name;
+        var errorTooShort = new Error("Too short");
+        var resultName = command.ParseMember(
+            nameSelector = c => c.Name,
+            name => OkIf(
+                name.Length > 3,
+                name,
+                errorTooShort));
+
+        var valid = resultAge.ZipWith(resultName, (age, name) => new ValidCommand(name, age));
+        valid.Errors.Should()
+            .BeEquivalentTo(
+                ImmutableList.Create(
+                    new MemberError(
+                        nameof(Command.Age),
+                        "The user should be an adult",
+                        ImmutableList.Create(errorTooYoung)),
+                    new MemberError(
+                        nameof(Command.Name),
+                        "",
+                        ImmutableList.Create(errorTooShort))));
+    }
+
+    [Fact(DisplayName = "Validates asynchronously values without errors")]
+    public async Task ValidateAsynchronouslyValuesWithoutErrors()
+    {
+        var result = await new Command("R", 20).ParseMemberAsync(
+            c => c.Age,
+            age => ValueTask.FromResult(
+                OkIf(
+                    age > 18,
+                    age,
+                    new Error("Too young"))));
+
+        result.Should()
+            .ContainValue();
+    }
+
+    [Fact(DisplayName = "Validates asynchronously values that produce errors")]
+    public async Task ValidateAsynchronouslyValuesThatProducesErrors()
+    {
+        var command = new Command("R", 13);
+
+        var resultAge = await command.ParseMemberAsync(
+            c => c.Age,
+            age => ValueTask.FromResult(
+                OkIf(
+                    age > 18,
+                    age,
+                    new Error("Too young"))),
+            "The user should be an adult");
+
+        var resultName = await command.ParseMemberAsync(
+            c => c.Name,
+            name => ValueTask.FromResult(
+                OkIf(
+                    name.Length > 3,
+                    name,
+                    new Error("Too short"))));
+
+        var valid = resultAge.ZipWith(resultName, (age, name) => new ValidCommand(name, age));
+        valid.Errors.Should()
+            .BeEquivalentTo(
+                ImmutableList.Create(
+                    new MemberError(
+                        nameof(Command.Age),
+                        "The user should be an adult",
+                        ImmutableList.Create(new Error("Too young"))),
+                    new MemberError(
+                        nameof(Command.Name),
+                        "",
+                        ImmutableList.Create(new Error("Too short")))));
+    }
+
+    [Fact(DisplayName = "Uses the JsonPropertyNameAttribute for a member name")]
+    public void UsesTheJsonPropertyNameAttributeForAMemberName()
+    {
+        var result = new Named("R", 7).ParseMember(
+            n => n.Name,
+            name => OkIf(
+                name.Length > 3,
+                name,
+                new Error("Too short")));
+
+        result.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Match<MemberError>(x => x.Member == "custom");
+    }
+
+    [Fact(DisplayName = "Uses the Naming Policy for a member name")]
+    public void UsesTheNamingPolicyForAMemberName()
+    {
+        MemberParser.DefaultNamingPolicy = new MyPolicy();
+
+        var result = new Named("R", 2).ParseMember(
+            n => n.CoVariant,
+            roads => OkIf(
+                roads > 3,
+                roads,
+                new Error("Not enough")),
+            propertyNamingPolicy: JsonNamingPolicy.CamelCase);
+
+        result.Errors.Should()
+            .SatisfyRespectively(
+                static single =>
+                    single.Should()
+                        .Match<MemberError>(static x => x.Member == "coVariant"));
+    }
+
+    [Fact(DisplayName = "Uses the default Naming Policy for a member name")]
+    public void UsesTheDefaultNamingPolicyForAMemberName()
+    {
+        MemberParser.DefaultNamingPolicy = new MyPolicy();
+
+        var result = new Named("R", 2).ParseMember(
+            n => n.CoVariant,
+            roads => OkIf(
+                roads > 3,
+                roads,
+                new Error("Not enough")));
+
+        result.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Match<MemberError>(x => x.Member == "covariant");
+    }
+
+    [Fact(DisplayName = "Prints the expression if it is not a member")]
+    public void PrintsTheExpressionIfItIsNotAMember()
+    {
+        var result = new Named("R", 2).ParseMember(
+            n => "I am using this wrong",
+            roads => Fail(new Error("Weird case")));
+
+        result.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .BeEquivalentTo(
+                new MemberError(
+                    "\"I am using this wrong\"",
+                    "",
+                    ImmutableList.Create(new Error("Weird case"))));
+    }
+
+    private record struct Command(string Name, int Age);
+
+    private record struct Named(
+        [property: JsonPropertyName("custom")]
+        string Name,
+        int CoVariant);
+
+    private record struct ValidCommand(string Name, int Age);
+
+    private class MyPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name) => name.ToLowerInvariant();
+    }
+}

--- a/src/Results.Immutable/Member/MemberError.cs
+++ b/src/Results.Immutable/Member/MemberError.cs
@@ -1,0 +1,28 @@
+namespace Results.Immutable.Member;
+
+/// <summary>
+///     A piece of information that describes an expected failure in an operation related to a member of a type.
+///     Generally used for direct members of a type, and yet it is possible to have nested members
+///     via the <paramref name="InnerErrors" /> parameter.
+/// </summary>
+/// <param name="Member">The name of the member.</param>
+/// <param name="Message">A message that describes the error.</param>
+/// <param name="InnerErrors">Another errors that caused this error, related to members of the member.</param>
+public record MemberError(
+    string Member,
+    string Message,
+    ImmutableList<Error> InnerErrors) : Error(Message, InnerErrors)
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MemberError" /> class.
+    /// </summary>
+    /// <param name="member">The path to the member.</param>
+    /// <param name="message">A message that describes the error.</param>
+    public MemberError(string member, string message)
+        : this(
+            member,
+            message,
+            ImmutableList<Error>.Empty)
+    {
+    }
+}

--- a/src/Results.Immutable/Member/MemberParser.cs
+++ b/src/Results.Immutable/Member/MemberParser.cs
@@ -1,0 +1,103 @@
+using System.Linq.Expressions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Results.Immutable.Member;
+
+/// <summary>
+///     A set of extensions methods for all types for parsing or validating members of an object by selecting it and then
+///     evaluating a function that returns a result. The returned error is wrapped in a <see cref="MemberError" /> with
+///     information about the member that caused the error.
+/// </summary>
+public static class MemberParser
+{
+    /// <summary>
+    ///     Gets or sets the default name policy to use when validating a member.
+    ///     This is optional and used to modify the casing of the member name.
+    ///     If not set, the original name is used as is.
+    /// </summary>
+    public static JsonNamingPolicy? DefaultNamingPolicy { get; set; }
+
+    /// <summary>
+    ///     Parses a member of an object and returns a result containing a <see cref="MemberError" />
+    ///     with information of the path to the member and the error message.
+    /// </summary>
+    /// <param name="obj">The object containing the member to parse/validate.</param>
+    /// <param name="memberSelector">The selector for the member.</param>
+    /// <param name="parser">A function that validates and parses the member.</param>
+    /// <param name="message">A message to add to the error in case of failure.</param>
+    /// <param name="propertyNamingPolicy">
+    ///     The name policy to use when validating the member, if not provided
+    ///     <see cref="DefaultNamingPolicy" /> is used.
+    /// </param>
+    /// <typeparam name="TObject">The type of the object containing the member.</typeparam>
+    /// <typeparam name="TMember">The type of the member.</typeparam>
+    /// <typeparam name="TParsed">The type of the produced value after parsing the member.</typeparam>
+    /// <returns></returns>
+    public static Result<TParsed> ParseMember<TObject, TMember, TParsed>(
+        this TObject obj,
+        Expression<Func<TObject, TMember>> memberSelector,
+        Func<TMember, Result<TParsed>> parser,
+        string message = "",
+        JsonNamingPolicy? propertyNamingPolicy = null) =>
+        MapErrorsAsMemberErrors(
+            memberSelector,
+            parser(memberSelector.Compile()(obj)),
+            message,
+            propertyNamingPolicy);
+
+    /// <inheritdoc
+    ///     cref="ParseMember{TObject, TMember, TParsed}(TObject, Expression{Func{TObject, TMember}}, Func{TMember, Result{TParsed}}, string, JsonNamingPolicy?)" />
+    public static async ValueTask<Result<TParsed>> ParseMemberAsync<TObject, TMember, TParsed>(
+        this TObject obj,
+        Expression<Func<TObject, TMember>> memberSelector,
+        Func<TMember, ValueTask<Result<TParsed>>> parser,
+        string message = "",
+        JsonNamingPolicy? propertyNamingPolicy = null) =>
+        MapErrorsAsMemberErrors(
+            memberSelector,
+            await parser(memberSelector.Compile()(obj)),
+            message,
+            propertyNamingPolicy);
+
+    private static Result<TParsed> MapErrorsAsMemberErrors<TObject, TResult, TParsed>(
+        Expression<Func<TObject, TResult>> memberExpression,
+        Result<TParsed> result,
+        string message,
+        JsonNamingPolicy? propertyNamingPolicy)
+    {
+        if (result.IsOk)
+        {
+            return result;
+        }
+
+        return Result.Fail<TParsed>(
+            new MemberError(
+                SerializeExpression(memberExpression, propertyNamingPolicy),
+                message,
+                result.Errors));
+    }
+
+    private static string SerializeExpression(LambdaExpression expression, JsonNamingPolicy? propertyNamingPolicy)
+    {
+        if (expression.Body is not MemberExpression { Member: { Name: var name, CustomAttributes: var attributes, }, })
+        {
+            return expression.Body.ToString();
+        }
+
+        var firstPropName =
+            attributes.FirstOrDefault(a => a.AttributeType.Equals(typeof(JsonPropertyNameAttribute)));
+
+        if (firstPropName is { ConstructorArguments: { Count: 1, } arguments, } && arguments.First() is { } arg)
+        {
+            return (string)arg.Value!;
+        }
+
+        if ((propertyNamingPolicy ?? DefaultNamingPolicy) is { } policy)
+        {
+            return policy.ConvertName(name);
+        }
+
+        return name;
+    }
+}

--- a/src/Results.Immutable/README.md
+++ b/src/Results.Immutable/README.md
@@ -1,1 +1,65 @@
 # Results.Immutable
+
+## Parsing and validating members of object
+
+This library provides an API to quickly validate/parse user input such as queries and requests and convert them into a well-typed
+structure as in Type-Driven Development (TDD) or Domain-Driven Development (DDD). Also, this technique allows to
+reuse fetched data used for validation for further use without having to re-fetch it.
+
+### Usage
+
+Example, using repository patterns to fetch data.
+
+```cs
+// User input
+record AddCityCommand(string CityName, string StateName);
+// Validated and typed input to be used further in the application
+record AddCityCommandParsed (City City, State State);
+
+// ...
+private async Task<Result<AddCityCommandParsed>> ParseInput(AddCityCommand addCityCommand)
+{
+    var city = await addCityCommand.ParseMemberAsync(
+        c => c.CityName,
+        async cityName =>
+        {
+            var city = await CityRepository.GetCity(cityName);
+            return Result.OkIf(city is not null, city, new NotFound());
+
+        },
+        "City name is required"
+    );
+
+    var state = await addCityCommand.ParseMemberAsync(
+        c => c.StateName,
+        async stateName =>
+        {
+            var state = await StateRepository.GetState(stateName);
+            return Result.OkIf(state is not null, state, new NotFound());
+
+        },
+        "State name is required"
+    );
+
+    return city.ZipWith(state, (city, state) => new AddCityCommandParsed(city, state));
+}
+// ...
+```
+
+In case that there is no `State` for the given `StateName`, the `Result` will return an `Error` with a `NotFound` error, like this:
+
+```json
+[
+  {
+    "Member": "State",
+    "Message": "State name is required",
+    "InnerErrors": [{ "Message": "not found" }]
+  }
+]
+```
+
+The casing of the member name in the error can be controlled using the `propertyNamingPolicy` of the `ParseMember` and `ParseMemberAsync` methods. Additionally, globally via the static property `MemberParser.DefaultNamingPolicy`. Both require a `JsonNamingPolicy` from the `System.Text.Json` namespace. This is simply reusing the included naming policies included in .NET, however, you can use any library for serializing in any format.
+
+To rename the name reported in the `Member` property, a `[JsonPropertyName]` can be used in the member, this also doesn't hinder the usage with other serializing libraries.
+
+Needless to say, this functionality only works with direct members. If the expression doesn't contain a member access, it will return the stringified version of the expression in the `Member` property. If nested accessing is used in the expression, only the direct member is reported in the `Member` property. For nesting, it is recommended to use the `ParseMember` in nested way.


### PR DESCRIPTION
First part of a series that will allow to integrate results with problem details and standalone json conversions of errors, the goal is to have practical parsing/validation for input objects and report back the errors in their members.