### PR TITLE
feat: return concrete type when calling `WithRootCauses` instead of `…

### DIFF
--- a/src/Results.Immutable.Tests/ErrorTests.cs
+++ b/src/Results.Immutable.Tests/ErrorTests.cs
@@ -1,0 +1,54 @@
+﻿namespace Results.Immutable.Tests;
+
+public class ErrorTests
+{
+    [Fact(DisplayName = "Adds additional errors to an error")]
+    public void AddAdditionalErrorsToAnError()
+    {
+        var error = new PiggyBankError("full of pennies", ImmutableList<Error>.Empty);
+        Error rootCause = new("too many pennies");
+        var newError = error
+            .WithRootCauses(ImmutableList.Create(rootCause));
+
+        newError.Should()
+            .NotBe(error);
+
+        newError.Should()
+            .BeOfType<PiggyBankError>();
+
+        newError.Message.Should()
+            .Be("full of pennies");
+
+        newError.InnerErrors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(rootCause);
+    }
+
+    [Fact(DisplayName = "Adds an additional error to an error")]
+    public void AddAnAdditionalErrorToAnError()
+    {
+        var error = new PiggyBankError("full of pennies", ImmutableList<Error>.Empty);
+        Error rootCause = new("too many pennies");
+        var newError = error
+            .WithRootCause(rootCause);
+
+        newError.Should()
+            .NotBe(error);
+
+        newError.Should()
+            .BeOfType<PiggyBankError>();
+
+        newError.Message.Should()
+            .Be("full of pennies");
+
+        newError.InnerErrors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(rootCause);
+    }
+
+    private record PiggyBankError(
+        string Message,
+        ImmutableList<Error> InnerErrors) : Error<PiggyBankError>(Message, InnerErrors);
+}

--- a/src/Results.Immutable.Tests/ExtensionsTests/ResultOptionConvertExtensionsTests.cs
+++ b/src/Results.Immutable.Tests/ExtensionsTests/ResultOptionConvertExtensionsTests.cs
@@ -12,14 +12,14 @@ public sealed class ResultOptionConvertExtensionsTests
     [Fact(DisplayName = "Converts an option with some value to a result")]
     public void ConvertsAnOptionWithSomeValueToAResult() =>
         Option.Some(5)
-            .ToResult(Error.Create("error"))
+            .ToResult(new Error("error"))
             .Should()
             .Be(Result.Ok(5));
 
     [Fact(DisplayName = "Converts an option with some value to a result with error factory")]
     public void ConvertsAnOptionWithSomeValueToAResultWithErrorFactory() =>
         Option.Some(5)
-            .ToResult(() => Error.Create("error"))
+            .ToResult(() => new("error"))
             .Should()
             .Be(Result.Ok(5));
 

--- a/src/Results.Immutable.Tests/Generators/ResultOf.cs
+++ b/src/Results.Immutable.Tests/Generators/ResultOf.cs
@@ -8,7 +8,7 @@ internal static class ResultOf<T>
     public static Gen<Result<T>> Generator() =>
         Gen.OneOf(
             ArbMap.Default.GeneratorFor<ImmutableList<string>>()
-                .Select(errors => Result.Fail<T>(errors.Select(Error.Create))),
+                .Select(errors => Result.Fail<T>(errors.Select(e => new Error(e)))),
             ArbMap.Default.GeneratorFor<T>()
                 .Select(Result.Ok));
 }

--- a/src/Results.Immutable/Error.cs
+++ b/src/Results.Immutable/Error.cs
@@ -3,6 +3,8 @@
 /// <summary>
 ///     A piece of information that describes an expected failure in an operation.
 /// </summary>
+/// <param name="Message">A message that describes the error.</param>
+/// <param name="InnerErrors">A list of errors that caused this error.</param>
 public record Error(
     string Message,
     ImmutableList<Error> InnerErrors)
@@ -31,17 +33,45 @@ public record Error(
     }
 
     /// <summary>
-    ///     Creates a new <see cref="Error" /> with provided <paramref name="message" />.
+    ///     With a new <see cref="Error" /> that will be added to the existing list of inner <see cref="Error" />s.
     /// </summary>
-    /// <param name="message">The message that describes the <see cref="Error" />.</param>
-    public static Error Create(string message) => new(message);
+    /// <param name="error">Another error that caused this error to occur.</param>
+    public Error WithRootCause(Error error) =>
+        this with
+        {
+            InnerErrors = InnerErrors.Add(error),
+        };
 
+    /// <summary>
+    ///     With new <see cref="Error" />s that will be added to the existing list of inner <see cref="Error" />s.
+    /// </summary>
+    /// <param name="errors">
+    ///     A collection of errors that caused this error to occur.
+    /// </param>
+    public Error WithRootCauses(IEnumerable<Error> errors) =>
+        this with
+        {
+            InnerErrors = InnerErrors.AddRange(errors),
+        };
+}
+
+/// <summary>
+///     A piece of information that describes an expected failure in an operation.
+///     This class is intended to be used as base class for new error types.
+/// </summary>
+/// <typeparam name="TError">The type of the inheriting error.</typeparam>
+/// <inheritdoc />
+public abstract record Error<TError>(
+    string Message,
+    ImmutableList<Error> InnerErrors) : Error(Message, InnerErrors)
+    where TError : Error<TError>
+{
     /// <summary>
     ///     With a new <see cref="Error" /> that will be added to the existing list of inner <see cref="Error" />s.
     /// </summary>
-    /// <param name="message">A new message that describes the <see cref="Error" />.</param>
-    public Error WithRootCause(Error error) =>
-        this with
+    /// <param name="error">A new message that describes the <see cref="Error" />.</param>
+    public new TError WithRootCause(Error error) =>
+        (TError)this with
         {
             InnerErrors = InnerErrors.Add(error),
         };
@@ -53,8 +83,8 @@ public record Error(
     ///     A collection of new <see cref="Error" />s that will be added to the existing list of inner
     ///     <see cref="Error" />s.
     /// </param>
-    public Error WithRootCauses(IEnumerable<Error> errors) =>
-        this with
+    public new TError WithRootCauses(IEnumerable<Error> errors) =>
+        (TError)this with
         {
             InnerErrors = InnerErrors.AddRange(errors),
         };

--- a/src/Results.Immutable/Member/IndexError.cs
+++ b/src/Results.Immutable/Member/IndexError.cs
@@ -7,11 +7,11 @@ namespace Results.Immutable.Member;
 /// </summary>
 /// <param name="Index">The name of the member.</param>
 /// <param name="Message">A message that describes the error.</param>
-/// <param name="InnerErrors">Another errors that caused this error, related to members of the member.</param>
+/// <param name="InnerErrors">A list of errors that caused this error, related to item.</param>
 public record IndexError(
     int Index,
     string Message,
-    ImmutableList<Error> InnerErrors) : Error(Message, InnerErrors)
+    ImmutableList<Error> InnerErrors) : Error<IndexError>(Message, InnerErrors)
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="IndexError" /> class.

--- a/src/Results.Immutable/Member/MemberError.cs
+++ b/src/Results.Immutable/Member/MemberError.cs
@@ -7,11 +7,11 @@ namespace Results.Immutable.Member;
 /// </summary>
 /// <param name="Member">The name of the member.</param>
 /// <param name="Message">A message that describes the error.</param>
-/// <param name="InnerErrors">Another errors that caused this error, related to members of the member.</param>
+/// <param name="InnerErrors">A list of errors that caused this error, related to member.</param>
 public record MemberError(
     string Member,
     string Message,
-    ImmutableList<Error> InnerErrors) : Error(Message, InnerErrors)
+    ImmutableList<Error> InnerErrors) : Error<MemberError>(Message, InnerErrors)
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="MemberError" /> class.

--- a/src/Results.Immutable/README.md
+++ b/src/Results.Immutable/README.md
@@ -101,3 +101,17 @@ var result = dictionary.ParsePairs(
 In case of errors, `MemberError`s will be returned with the `InnerErrors` of the `Error` returned by the parser, similar to `ParseMember`. The function for parsing can return a `Result` of `KeyValuePair` which its key can be of any type.
 
 For validating dictionaries which its keys are not of type `string`, use the `ParseEach` method and its variants.
+
+## Creating custom errors
+
+The true richness of this library lies in the ability to inform accurately the error of some operation. For this, it is advised to create your own error types instead of using the plain `Error` type included in this library. Said `Error` should be seen as a base type for more specific errors or as an inner error. It is a good practice to always create concrete types for your domain or infrastructure.
+
+It is advised to extend the type `Error<TError>` instead of `Error` to get a better developer experience thanks to its proper typing of method such as `WithRootCause`.
+
+Example:
+
+```cs
+private record PiggyBankError(
+    string Message,
+    ImmutableList<Error> InnerErrors) : Error<PiggyBankError>(Message, InnerErrors);
+```


### PR DESCRIPTION
BREAKING CHANGE: remove `Error.Create`

A quality of life improvement to use `WithRootCause` without having to cast it down after usage.

The `Error.Create` is basically useless, since it cannot return the concrete types, removed.