### PR TITLE
Add error projections

### DIFF
--- a/src/Results.Immutable.Tests/ResultTests/ErrorProjectionTests.cs
+++ b/src/Results.Immutable.Tests/ResultTests/ErrorProjectionTests.cs
@@ -1,0 +1,91 @@
+﻿namespace Results.Immutable.Tests.ResultTests;
+
+public sealed class ErrorProjectionTests
+{
+    private static readonly Result<Unit> SuccessfulResult = Result.Ok();
+
+    private static readonly Result<Unit> FailedResult = Result.Fail(
+        ImmutableList.Create(
+            new Error(
+                "First top-level",
+                new SubError("Root cause")),
+            new Error("Second top-level error")));
+
+    [Fact(DisplayName = "SelectErrors on a successful result is a no-op")]
+    public void SelectErrorsOnASuccessfulResultIsANoOp()
+    {
+        var errorsProjection = new Fn<Error, SubError>(error => new(error.Message, error.InnerErrors));
+
+        SuccessfulResult.SelectErrors(errorsProjection.Callable)
+            .Should()
+            .Be(SuccessfulResult);
+
+        errorsProjection.CallCount.Should()
+            .Be(0);
+    }
+
+    [Fact(DisplayName = "MergeErrorsWith on a successful result is a no-op")]
+    public void MergeErrorsWithOnASuccessfulResultIsANoOp()
+    {
+        var errorsCombinator =
+            new Fn<ImmutableList<Error>, SubError>(static errors => new("Welp, this should not work", errors));
+
+        SuccessfulResult.MergeErrorsWith(errorsCombinator.Callable)
+            .Should()
+            .Be(SuccessfulResult);
+
+        errorsCombinator.CallCount
+            .Should()
+            .Be(0);
+    }
+
+    [Fact(DisplayName = "SelectErrors on a failed result projects all top-level errors")]
+    public void SelectErrorsOnAFailedResultProjectsAllRootErrors()
+    {
+        var errorsSelector =
+            new Fn<Error, Error>(e => new($"Original message: {e.Message}", ImmutableList<Error>.Empty));
+
+        var resultWithProjectedErrors = FailedResult.SelectErrors(errorsSelector.Callable);
+
+        resultWithProjectedErrors.Should()
+            .NotBe(FailedResult);
+
+        errorsSelector.CallCount.Should()
+            .Be((uint)FailedResult.Errors.Count);
+
+        resultWithProjectedErrors.HasError<SubError>()
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact(DisplayName = "MergeErrorsWith on a failed result combines all top-level errors")]
+    public void MergeErrorsWithOnAFailedResultCombinesAllTopLevelErrors()
+    {
+        var errorsCombinator = new Fn<ImmutableList<Error>, Error>(
+            es => new SubError(
+                "By your powers combined, I fail this operation!",
+                es));
+
+        var resultWithZippedErrors = FailedResult.MergeErrorsWith(errorsCombinator.Callable);
+
+        resultWithZippedErrors
+            .Should()
+            .NotBe(FailedResult);
+
+        errorsCombinator.CallCount.Should()
+            .Be(1);
+
+        resultWithZippedErrors.Errors.Should()
+            .SatisfyRespectively(
+                single => single.InnerErrors.Should()
+                    .BeEquivalentTo(FailedResult.Errors));
+    }
+
+    private sealed record SubError(string Message, ImmutableList<Error> InnerErrors) : Error(Message, InnerErrors)
+    {
+        public SubError(string message)
+            : this(message, ImmutableList<Error>.Empty)
+        {
+        }
+    }
+}

--- a/src/Results.Immutable/Projections/Result/SelectErrors.cs
+++ b/src/Results.Immutable/Projections/Result/SelectErrors.cs
@@ -1,0 +1,35 @@
+﻿namespace Results.Immutable;
+
+public readonly partial struct Result<T>
+{
+    /// <summary>
+    ///     Projects all errors associated with this <see cref="Result{T}" />
+    ///     using provided <paramref name="errorSelector" />.
+    /// </summary>
+    /// <param name="errorSelector">Selector used for <see cref="Errors" /> projection.</param>
+    /// <returns>
+    ///     The same result if it <see cref="HasSucceeded" />, otherwise -
+    ///     new <see cref="Result{T}" /> with transformed <see cref="Errors" />.
+    /// </returns>
+    public Result<T> SelectErrors(Func<Error, Error> errorSelector) =>
+        this is { Some.Value: _, } ? this : new(ImmutableList.CreateRange(Errors.Select(errorSelector)));
+
+    /// <summary>
+    ///     Zips all errors associated with this <see cref="Result{T}" />
+    ///     into one error using provided <paramref name="errorsCombinator" />.
+    /// </summary>
+    /// <typeparam name="TError">Generic type of the projected error.</typeparam>
+    /// <param name="errorsCombinator">Combinator of the <see cref="Errors" />.</param>
+    /// <returns>
+    ///     The same result if it <see cref="HasSucceeded" />, otherwise -
+    ///     new <see cref="Result{T}" /> with errors flattened into one.
+    /// </returns>
+    /// <remarks>
+    ///     It is strongly recommended to leverage
+    ///     <see cref="Error.WithRootCauses(IEnumerable{Error})" /> in the
+    ///     <paramref name="errorsCombinator" />.
+    /// </remarks>
+    public Result<T> MergeErrorsWith<TError>(Func<ImmutableList<Error>, TError> errorsCombinator)
+        where TError : Error =>
+        this is { Some.Value: _, } ? this : new(ImmutableList.Create<Error>(errorsCombinator(Errors)));
+}


### PR DESCRIPTION
Should be merged after #87

Adds following projections for errors:

- `SelectErrors` projects all errors associated with the result.
- `SelectManyErrors` combines all errors into one (should be used in conjunction with `Error.WithRootCauses`).